### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/publications.rst
+++ b/publications.rst
@@ -1,22 +1,22 @@
 Publications
 ============
 Hillion K.H., Kuzmin I., Khodak A., Rasche E., Crusoe M., Peterson H., Ison J., Ménager, H.  (2017). `Using bio.tools to generate and annotate workbench tool descriptions <https://f1000research.com/articles/6-2074/v1>`_  F1000Research 2017 (article).
-doi:`10.12688/f1000research.12974.1 <https://dx.doi.org/10.12688/f1000research.12974.1>`_
+doi:`10.12688/f1000research.12974.1 <https://doi.org/10.12688/f1000research.12974.1>`_
 
-Doppelt-Azeroual, O., Mareuil, F., Deveaud, Kalaš, M., Soranzo, N., van den Beek, M., Grüning, B., Ison, J. and Ménager, H. (2017).  `ReGaTE: Registration of Galaxy Tools in Elixir <https://doi.org/10.1093/gigascience/gix022>`_  *GigaScience*,  doi:`10.1093/gigascience/gix022 <https://dx.doi.org/10.1093/gigascience/gix022>`_
+Doppelt-Azeroual, O., Mareuil, F., Deveaud, Kalaš, M., Soranzo, N., van den Beek, M., Grüning, B., Ison, J. and Ménager, H. (2017).  `ReGaTE: Registration of Galaxy Tools in Elixir <https://doi.org/10.1093/gigascience/gix022>`_  *GigaScience*,  doi:`10.1093/gigascience/gix022 <https://doi.org/10.1093/gigascience/gix022>`_
 
-Ménager, H., Kalaš, M., Rapacki, K. and Ison, J. (2016).  `Using registries to integrate bioinformatics tools and services into workbench environments <https://link.springer.com/article/10.1007/s10009-015-0392-z>`_  *Int J Softw Tools Technol Transfer*,  doi:`10.1007/s10009-015-0392-z <https://dx.doi.org/10.1007/s10009-015-0392-z>`_
+Ménager, H., Kalaš, M., Rapacki, K. and Ison, J. (2016).  `Using registries to integrate bioinformatics tools and services into workbench environments <https://link.springer.com/article/10.1007/s10009-015-0392-z>`_  *Int J Softw Tools Technol Transfer*,  doi:`10.1007/s10009-015-0392-z <https://doi.org/10.1007/s10009-015-0392-z>`_
 
-Ison, J. et al. (2015). `Tools and data services registry: a community effort to document bioinformatics resources. <http://nar.oxfordjournals.org/content/early/2015/11/03/nar.gkv1116.long>`_ *Nucleic Acids Research*,  doi: `10.1093/nar/gkv1116 <https://dx.doi.org/10.1093/nar/gkv1116>`_ 
+Ison, J. et al. (2015). `Tools and data services registry: a community effort to document bioinformatics resources. <http://nar.oxfordjournals.org/content/early/2015/11/03/nar.gkv1116.long>`_ *Nucleic Acids Research*,  doi: `10.1093/nar/gkv1116 <https://doi.org/10.1093/nar/gkv1116>`_ 
 
-Ison, J., Kalaš, M., Jonassen, I., Bolser, D., Uludag, M., McWilliam, H., Malone, J., Lopez, R., Pettifer, S. and Rice, P. (2013). `EDAM: an ontology of bioinformatics operations, types of data and identifiers, topics and formats <http://bioinformatics.oxfordjournals.org/content/29/10/1325.full>`_ *Bioinformatics*, doi: `10.1093/bioinformatics/btt113 <https://dx.doi.org/10.1093/bioinformatics/btt113>`_ 
+Ison, J., Kalaš, M., Jonassen, I., Bolser, D., Uludag, M., McWilliam, H., Malone, J., Lopez, R., Pettifer, S. and Rice, P. (2013). `EDAM: an ontology of bioinformatics operations, types of data and identifiers, topics and formats <http://bioinformatics.oxfordjournals.org/content/29/10/1325.full>`_ *Bioinformatics*, doi: `10.1093/bioinformatics/btt113 <https://doi.org/10.1093/bioinformatics/btt113>`_ 
 
 Citation
 --------
 If you use bio.tools, please cite:
 
-Ison, J. et al. (2015). `Tools and data services registry: a community effort to document bioinformatics resources. <http://nar.oxfordjournals.org/content/early/2015/11/03/nar.gkv1116.long>`_ *Nucleic Acids Research.*  doi: `10.1093/nar/gkv1116 <https://dx.doi.org/10.1093/nar/gkv1116>`_ 
+Ison, J. et al. (2015). `Tools and data services registry: a community effort to document bioinformatics resources. <http://nar.oxfordjournals.org/content/early/2015/11/03/nar.gkv1116.long>`_ *Nucleic Acids Research.*  doi: `10.1093/nar/gkv1116 <https://doi.org/10.1093/nar/gkv1116>`_ 
 
 If you use EDAM or its part, please cite:
 
-Ison, J., Kalaš, M., Jonassen, I., Bolser, D., Uludag, M., McWilliam, H., Malone, J., Lopez, R., Pettifer, S. and Rice, P. (2013). `EDAM: an ontology of bioinformatics operations, types of data and identifiers, topics and formats <http://bioinformatics.oxfordjournals.org/content/29/10/1325.full>`_ *Bioinformatics*, doi: `10.1093/bioinformatics/btt113 <https://dx.doi.org/10.1093/bioinformatics/btt113>`_ 
+Ison, J., Kalaš, M., Jonassen, I., Bolser, D., Uludag, M., McWilliam, H., Malone, J., Lopez, R., Pettifer, S. and Rice, P. (2013). `EDAM: an ontology of bioinformatics operations, types of data and identifiers, topics and formats <http://bioinformatics.oxfordjournals.org/content/29/10/1325.full>`_ *Bioinformatics*, doi: `10.1093/bioinformatics/btt113 <https://doi.org/10.1093/bioinformatics/btt113>`_ 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org) and the old links with the `dx` subdomain continue to work.

Although there is no urgent need to do anything, I'd hereby like to suggest to follow the new recommendation and update all static DOI links and any code that generates new DOI links.

Cheers!